### PR TITLE
update dependency target location

### DIFF
--- a/actors/locator/Cargo.toml
+++ b/actors/locator/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 authors = ["Dave Yarwood <dave.yarwood@gmail.com>"]
 
 [dependencies]
-schemamama_rusqlite = { git = "https://github.com/marado/schemamama_rusqlite" }
+schemamama_rusqlite = { git = "https://github.com/cmsd2/schemamama_rusqlite" }
 schemamama          = "0.2.1"
 rusqlite            = "0.6.1"
 time                = "0.1.35"


### PR DESCRIPTION
schemamama_rusqlite had a broken dependency, so we started to depending on a
fork that had that fixed. Since that fix is now merged upstream, this patch
makes us point to the official repository instead.

We're still pointing to the git repository instead of genericly refering to the
crate of the new version, since that crate wasn't published yet.